### PR TITLE
Fixing bytes and subscription

### DIFF
--- a/ProcessRunner.Tests/BaseProcessRunnerTests.cs
+++ b/ProcessRunner.Tests/BaseProcessRunnerTests.cs
@@ -891,18 +891,22 @@ namespace NanoDNA.ProcessRunner.Tests
         {
             TestRunner runner = new TestRunner(DEFAULT_VALID_APPLICATION);
             bool outputReceived = false;
+            string output = "";
 
             runner.STDOutputReceived += (sender, e) =>
             {
-                Console.WriteLine("IDK");
                 if (e.Data != null)
+                {
                     outputReceived = true;
+                    output = e.Data;
+                }
             };
 
             Result<int> result = runner.Run(DEFAULT_APPLICATION_COMMAND);
 
             Assert.That(result.Status, Is.EqualTo(ResultStatus.Success));
             Assert.That(outputReceived, Is.True);
+            Assert.That(output, Is.EqualTo(DEFAULT_PROCESS_OUTPUT));
         }
 
         /// <summary>
@@ -1043,6 +1047,190 @@ namespace NanoDNA.ProcessRunner.Tests
 
             Assert.That(result.Status, Is.EqualTo(ResultStatus.Error));
             Assert.That(result.Message, Does.Contain("failed").Or.Contain("code"));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="BaseProcessRunner.Run(string, TimeSpan?)"/> captures raw bytes and encoded text formats without corruption.
+        /// </summary>
+        [Test]
+        public void RunWithRawBytesAndBase64OutputCapturesCorrectBytes()
+        {
+            string application = GetOSDefaultApplication();
+            TestRunner runner = new TestRunner(application);
+
+            byte[] rawBytes = new byte[] { 0x00, 0x01, 0x7F, 0x80, 0xFF, 0x3A };
+            string base64String = Convert.ToBase64String(rawBytes);
+            byte[] combinedBytes = System.Text.Encoding.UTF8.GetBytes("Payload:" + base64String + Environment.NewLine);
+
+            runner.StandardOutputReader.BaseStream.Write(combinedBytes, 0, combinedBytes.Length);
+
+            Assert.That(runner.STDOutputBytes, Is.EqualTo(combinedBytes));
+
+            string recoveredText = System.Text.Encoding.UTF8.GetString(runner.STDOutputBytes);
+            Assert.That(recoveredText, Does.Contain(base64String));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="BaseProcessRunner.RunAsync(string, CancellationToken)"/> extracts raw data variants via output and error arrays safely.
+        /// </summary>
+        [Test]
+        public async Task RunAsyncWithRawBytesAndBase64OutputCapturesCorrectBytes()
+        {
+            string application = GetOSDefaultApplication();
+            TestRunner runner = new TestRunner(application);
+
+            byte[] expectedOutputBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x0A };
+            byte[] expectedErrorBytes = new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0x20, 0x0D };
+
+            await runner.StandardOutputReader.BaseStream.WriteAsync(expectedOutputBytes, 0, expectedOutputBytes.Length);
+            await runner.StandardErrorReader.BaseStream.WriteAsync(expectedErrorBytes, 0, expectedErrorBytes.Length);
+
+            Assert.That(runner.STDOutputBytes, Is.EqualTo(expectedOutputBytes));
+            Assert.That(runner.STDErrorBytes, Is.EqualTo(expectedErrorBytes));
+        }
+
+        /// <summary>
+        /// Tests that sequential events split text line outputs into subscriptions systematically.
+        /// </summary>
+        [Test]
+        public void RunSubscriptionReceivesLineByLineOutputCorrectly()
+        {
+            TestRunner runner = new TestRunner(DEFAULT_VALID_APPLICATION);
+            List<string> lines = new List<string>();
+
+            runner.STDOutputReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                    lines.Add(e.Data);
+            };
+
+            byte[] buffer = System.Text.Encoding.UTF8.GetBytes("Line 1\nLine 2\r\nLine 3\n");
+            System.Text.StringBuilder lineBuilder = new System.Text.StringBuilder();
+
+            var method = typeof(BaseProcessRunner).GetMethod("SaveSTDOutput",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            method!.Invoke(runner, new object[] { buffer, buffer.Length, lineBuilder });
+
+            Assert.That(lines.Count, Is.EqualTo(3));
+            Assert.That(lines[0], Is.EqualTo("Line 1"));
+            Assert.That(lines[1], Is.EqualTo("Line 2"));
+            Assert.That(lines[2], Is.EqualTo("Line 3"));
+        }
+
+        /// <summary>
+        /// Tests that async process loops parse discrete tick sequences securely across active stream subscriptions.
+        /// </summary>
+        [Test]
+        public async Task RunAsyncSubscriptionReceivesLineByLineOutputCorrectly()
+        {
+            TestRunner runner = new TestRunner(DEFAULT_VALID_APPLICATION);
+            List<string> outputLines = new List<string>();
+            List<string> errorLines = new List<string>();
+
+            runner.STDOutputReceived += (sender, e) => { if (e.Data != null) outputLines.Add(e.Data); };
+            runner.STDErrorReceived += (sender, e) => { if (e.Data != null) errorLines.Add(e.Data); };
+
+            byte[] outBuffer = System.Text.Encoding.UTF8.GetBytes("Async Line 1\nAsync Line 2\n");
+            byte[] errBuffer = System.Text.Encoding.UTF8.GetBytes("Async Error Line 1\n");
+            System.Text.StringBuilder outBuilder = new System.Text.StringBuilder();
+            System.Text.StringBuilder errBuilder = new System.Text.StringBuilder();
+
+            var saveOutMethod = typeof(BaseProcessRunner).GetMethod("SaveSTDOutput", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var saveErrMethod = typeof(BaseProcessRunner).GetMethod("SaveSTDError", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            saveOutMethod!.Invoke(runner, new object[] { outBuffer, outBuffer.Length, outBuilder });
+            saveErrMethod!.Invoke(runner, new object[] { errBuffer, errBuffer.Length, errBuilder });
+
+            await Task.Yield();
+
+            Assert.That(outputLines.Count, Is.EqualTo(2));
+            Assert.That(outputLines[0], Is.EqualTo("Async Line 1"));
+            Assert.That(errorLines.Count, Is.EqualTo(1));
+            Assert.That(errorLines[0], Is.EqualTo("Async Error Line 1"));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="BaseProcessRunner"/> handles lines that do not end with a newline character correctly.
+        /// </summary>
+        [Test]
+        public void RunSubscriptionHandlesTrailingTextWithoutNewline()
+        {
+            TestRunner runner = new TestRunner(DEFAULT_VALID_APPLICATION);
+            List<string> lines = new List<string>();
+
+            runner.STDOutputReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                    lines.Add(e.Data);
+            };
+
+            byte[] buffer = System.Text.Encoding.UTF8.GetBytes("Line 1\nTrailing text");
+            System.Text.StringBuilder lineBuilder = new System.Text.StringBuilder();
+
+            var method = typeof(BaseProcessRunner).GetMethod("SaveSTDOutput",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            method!.Invoke(runner, new object[] { buffer, buffer.Length, lineBuilder });
+
+            Assert.That(lines.Count, Is.EqualTo(1));
+            Assert.That(lines[0], Is.EqualTo("Line 1"));
+            Assert.That(lineBuilder.ToString(), Is.EqualTo("Trailing text"));
+        }
+
+        /// <summary>
+        /// Tests that lines containing only whitespace characters are preserved and dispatched to the event receivers correctly.
+        /// </summary>
+        [Test]
+        public void RunSubscriptionHandlesWhitespaceLines()
+        {
+            TestRunner runner = new TestRunner(DEFAULT_VALID_APPLICATION);
+            List<string> lines = new List<string>();
+
+            runner.STDOutputReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                    lines.Add(e.Data);
+            };
+
+            byte[] buffer = System.Text.Encoding.UTF8.GetBytes("Line 1\n \nLine 3\n");
+            System.Text.StringBuilder lineBuilder = new System.Text.StringBuilder();
+
+            var method = typeof(BaseProcessRunner).GetMethod("SaveSTDOutput",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            method!.Invoke(runner, new object[] { buffer, buffer.Length, lineBuilder });
+
+            Assert.That(lines.Count, Is.EqualTo(3));
+            Assert.That(lines[0], Is.EqualTo("Line 1"));
+            Assert.That(lines[1], Is.EqualTo(" "));
+            Assert.That(lines[2], Is.EqualTo("Line 3"));
+        }
+
+        /// <summary>
+        /// Tests that zero or negative byte counts are rejected safely without invoking event subscribers.
+        /// </summary>
+        [Test]
+        public void SaveSTDOutputWithZeroCountDoesNotInvokeEvent()
+        {
+            TestRunner runner = new TestRunner(DEFAULT_VALID_APPLICATION);
+            bool eventTriggered = false;
+
+            runner.STDOutputReceived += (sender, e) =>
+            {
+                eventTriggered = true;
+            };
+
+            byte[] buffer = System.Text.Encoding.UTF8.GetBytes("Valid Line\n");
+            System.Text.StringBuilder lineBuilder = new System.Text.StringBuilder();
+
+            var method = typeof(BaseProcessRunner).GetMethod("SaveSTDOutput",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            method!.Invoke(runner, new object[] { buffer, 0, lineBuilder });
+
+            Assert.That(eventTriggered, Is.False);
+            Assert.That(runner.STDOutputBytes.Length, Is.EqualTo(0));
         }
     }
 }

--- a/ProcessRunner/BaseProcessRunner.cs
+++ b/ProcessRunner/BaseProcessRunner.cs
@@ -35,6 +35,14 @@ namespace NanoDNA.ProcessRunner
         /// </summary>
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
+        /// <summary>
+        /// Delegate function used to pass the <see cref="SaveSTDOutput(byte[], int, StringBuilder)"/> and <see cref="SaveSTDError(byte[], int, StringBuilder)"/> functions to the <see cref="CreateWriterTask(Stream, StreamChunkProcessor, DataReceivedEventHandler?)"/> function
+        /// </summary>
+        /// <param name="buffer">Buffer of bytes to write</param>
+        /// <param name="bytesRead">Number of bytes to write</param>
+        /// <param name="lineBuilder">The converted string line to construct from the bytes</param>
+        private delegate void StreamChunkProcessor(byte[] buffer, int bytesRead, StringBuilder lineBuilder);
+
         /// <inheritdoc />
         public string ApplicationName => StartInfo.FileName;
 
@@ -231,6 +239,8 @@ namespace NanoDNA.ProcessRunner
         /// <param name="lineBuilder">The converted string line to construct from the bytes</param>
         protected void SaveSTDOutput(byte[] buffer, int count, StringBuilder lineBuilder)
         {
+            Logger.Trace("Saving Data to STD Output");
+
             if (count <= 0)
                 return;
 
@@ -251,6 +261,8 @@ namespace NanoDNA.ProcessRunner
         /// <param name="lineBuilder">The converted string line to construct from the bytes</param>
         protected void SaveSTDError(byte[] buffer, int count, StringBuilder lineBuilder)
         {
+            Logger.Trace("Saving Data to STD Error");
+
             if (count <= 0)
                 return;
 
@@ -263,11 +275,18 @@ namespace NanoDNA.ProcessRunner
                 ParseAndInvokeLine(buffer, count, lineBuilder, line => STDErrorReceived?.Invoke(this, CreateEventArgs(line)));
         }
 
+        /// <summary>
+        /// Parses a raw byte buffer chunk into text strings line-by-line, omitting carriage returns, and dispatches them to a parsing action upon encountering a newline character.
+        /// </summary>
+        /// <param name="buffer">The raw byte array chunk received from the process stream.</param>
+        /// <param name="count">The number of valid bytes to read from the buffer.</param>
+        /// <param name="lineBuilder">The persistent string builder instance used to store and aggregate incomplete text fragments across chunks.</param>
+        /// <param name="onLineParsed">The callback action to execute with the string data whenever a complete line is parsed.</param>
         private void ParseAndInvokeLine(byte[] buffer, int count, StringBuilder lineBuilder, Action<string> onLineParsed)
         {
-            string textChunk = Encoding.UTF8.GetString(buffer, 0, count);
-
             Logger.Trace($"Parsing and Invoking line");
+
+            string textChunk = Encoding.UTF8.GetString(buffer, 0, count);
 
             for (int i = 0; i < textChunk.Length; i++)
             {
@@ -285,6 +304,11 @@ namespace NanoDNA.ProcessRunner
             }
         }
 
+        /// <summary>
+        /// Instantiates a new <see cref="DataReceivedEventArgs"/> instance by reflecting into its internal constructor to pass line data.
+        /// </summary>
+        /// <param name="lineData">The string data representing the parsed line to attach to the event arguments.</param>
+        /// <returns>A new non-null instance of <see cref="DataReceivedEventArgs"/> containing the line data.</returns>
         private DataReceivedEventArgs CreateEventArgs(string? lineData)
         {
             Logger.Trace("Creating Event Args for Invoke");
@@ -303,10 +327,17 @@ namespace NanoDNA.ProcessRunner
             )!;
         }
 
-        private delegate void StreamChunkProcessor(byte[] buffer, int bytesRead, StringBuilder lineBuilder);
-
+        /// <summary>
+        /// Creates a new Task to read from the specified process stream, process chunks via a delegate, and invoke the associated data handler.
+        /// </summary>
+        /// <param name="stream">The source process stream to read data from.</param>
+        /// <param name="processor">The chunk processor delegate responsible for handling the byte buffer and updating the string builder state.</param>
+        /// <param name="handler">The data received event handler to invoke when a full line or remaining text block is parsed.</param>
+        /// <returns>A running Task instance that performs the asynchronous stream reading loop.</returns>
         private Task CreateWriterTask(Stream stream, StreamChunkProcessor processor, DataReceivedEventHandler? handler)
         {
+            Logger.Trace("Creating new Write task instance");
+
             return Task.Run(async () =>
             {
                 StringBuilder lineBuilder = new StringBuilder();
@@ -328,6 +359,8 @@ namespace NanoDNA.ProcessRunner
         /// </summary>
         private async Task SafeAwaitStreamsAsync(List<Task> streamTasks)
         {
+            Logger.Trace("Waiting for the Writer Streams");
+
             try
             {
                 Task streamWaitTask = Task.WhenAll(streamTasks);
@@ -351,7 +384,7 @@ namespace NanoDNA.ProcessRunner
             string command = $"{ApplicationName} {args}";
             StartInfo.Arguments = args;
 
-            Logger.Info($"Running Command : {command}");
+            Logger.Debug($"Running Command : {command}");
 
             using (Process? process = Process.Start(StartInfo))
             {
@@ -391,7 +424,7 @@ namespace NanoDNA.ProcessRunner
                 if (process.ExitCode == 0)
                 {
                     Task.WaitAll(streamTasks.ToArray());
-                    Logger.Info($"Successfully Ran Command : {command}");
+                    Logger.Debug($"Successfully Ran Command : {command}");
                     return new Result<int>(ResultStatus.Success, process.ExitCode, $"Command executed successfully: {command}");
                 }
 
@@ -409,7 +442,7 @@ namespace NanoDNA.ProcessRunner
             string command = $"{ApplicationName} {args}";
             StartInfo.Arguments = args;
 
-            Logger.Info($"Running Command : {command}");
+            Logger.Debug($"Running Command : {command}");
 
             using (Process? process = Process.Start(StartInfo))
             {
@@ -465,7 +498,7 @@ namespace NanoDNA.ProcessRunner
 
                 if (process.ExitCode == 0)
                 {
-                    Logger.Info($"Successfully Ran Command : {command}");
+                    Logger.Debug($"Successfully Ran Command : {command}");
                     return new Result<int>(ResultStatus.Success, process.ExitCode, $"Command executed successfully: {command}");
                 }
 
@@ -499,7 +532,7 @@ namespace NanoDNA.ProcessRunner
         {
             if (!OperatingSystem.IsWindows())
             {
-                Logger.Info("Sending SIGTERM Signal");
+                Logger.Debug("Sending SIGTERM Signal");
 
                 ProcessStartInfo startInfo = new ProcessStartInfo()
                 {
@@ -525,7 +558,7 @@ namespace NanoDNA.ProcessRunner
                 return;
             }
 
-            Logger.Info("Sending Ctrl+C Command");
+            Logger.Debug("Sending Ctrl+C Command");
 
             process.StandardInput.WriteLine("\x3");
             process.StandardInput.Close();

--- a/ProcessRunner/BaseProcessRunner.cs
+++ b/ProcessRunner/BaseProcessRunner.cs
@@ -367,10 +367,9 @@ namespace NanoDNA.ProcessRunner
                 Task timeoutFallback = Task.Delay(2000);
 
                 Task completedTask = await Task.WhenAny(streamWaitTask, timeoutFallback).ConfigureAwait(false);
+
                 if (completedTask == timeoutFallback)
-                {
                     Logger.Warn("Stream synchronization tasks timed out during fallback termination.");
-                }
             }
             catch (Exception ex)
             {
@@ -395,6 +394,7 @@ namespace NanoDNA.ProcessRunner
                 }
 
                 List<Task> streamTasks = new List<Task>();
+
                 if (STDOutputRedirect)
                     streamTasks.Add(CreateWriterTask(process.StandardOutput.BaseStream, SaveSTDOutput, STDOutputReceived));
 
@@ -530,6 +530,8 @@ namespace NanoDNA.ProcessRunner
         /// <returns>Graceful cancellation task to be run</returns>
         private async Task CancelProcessGracefully(Process process)
         {
+            Logger.Trace("Cancelling the Process Gracefully");
+
             if (!OperatingSystem.IsWindows())
             {
                 Logger.Debug("Sending SIGTERM Signal");

--- a/ProcessRunner/BaseProcessRunner.cs
+++ b/ProcessRunner/BaseProcessRunner.cs
@@ -302,9 +302,9 @@ namespace NanoDNA.ProcessRunner
 
         private void ParseAndInvokeLine(byte[] buffer, int count, StringBuilder lineBuilder, Action<string> onLineParsed)
         {
-            Logger.Info("Parsing and Invoking line");
-
             string textChunk = Encoding.UTF8.GetString(buffer, 0, count);
+
+            Logger.Trace($"Parsing and Invoking line");
 
             for (int i = 0; i < textChunk.Length; i++)
             {
@@ -316,26 +316,20 @@ namespace NanoDNA.ProcessRunner
                     lineBuilder.Clear();
                 }
                 else if (c == '\r')
-                {
+                    continue;
+                else
                     lineBuilder.Append(c);
-                }
             }
         }
 
         private DataReceivedEventArgs CreateEventArgs(string? lineData)
         {
-            Logger.Info("Creating Event Args for Invoke");
+            Logger.Trace("Creating Event Args for Invoke");
 
             object[] data = new object[0];
 
             if (!string.IsNullOrEmpty(lineData))
-            {
-                Logger.Info("Stuffed with something")
                 data = new object[] { lineData };
-            }
-               
-
-            Logger.Info($"Data is : {data[0].ToString()}");
 
             return (DataReceivedEventArgs)Activator.CreateInstance(
                 typeof(DataReceivedEventArgs),

--- a/ProcessRunner/BaseProcessRunner.cs
+++ b/ProcessRunner/BaseProcessRunner.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using NanoDNA.AutomationResults;
 using System.Collections.Generic;
+using NLog.LayoutRenderers.Wrappers;
 
 namespace NanoDNA.ProcessRunner
 {
@@ -223,39 +224,167 @@ namespace NanoDNA.ProcessRunner
             Logger.Debug($"Working Directory : {path}");
         }
 
+        ///// <summary>
+        ///// Saves the standard output from the process internally.
+        ///// </summary>
+        ///// <param name="sender">Object sending the event</param>
+        ///// <param name="data">Data received by the event</param>
+        //protected void SaveSTDOutput(object sender, DataReceivedEventArgs data)
+        //{
+        //    string? output = data.Data;
+        //    if (output == null)
+        //        return;
+
+        //    lock (_outputLock)
+        //    {
+        //        byte[] bytes = Encoding.UTF8.GetBytes(output + Environment.NewLine);
+        //        _stdOutput.Write(bytes, 0, bytes.Length);
+        //    }
+        //}
+
+        ///// <summary>
+        ///// Saves the standard error from the process internally.
+        ///// </summary>
+        ///// <param name="sender">Object sending the event</param>
+        ///// <param name="data">Data received by the event</param>
+        //protected void SaveSTDError(object sender, DataReceivedEventArgs data)
+        //{
+        //    string? output = data.Data;
+        //    if (output == null)
+        //        return;
+
+        //    lock (_errorLock)
+        //    {
+        //        byte[] bytes = Encoding.UTF8.GetBytes(output + Environment.NewLine);
+        //        _stdError.Write(bytes, 0, bytes.Length);
+        //    }
+        //}
+
         /// <summary>
-        /// Saves the standard output from the process internally.
+        /// Saves the Standard Output from the process internally and invokes the receiver
         /// </summary>
-        /// <param name="sender">Object sending the event</param>
-        /// <param name="data">Data received by the event</param>
-        protected void SaveSTDOutput(object sender, DataReceivedEventArgs data)
+        /// <param name="buffer">Buffer of bytes to write</param>
+        /// <param name="count">Number of bytes to write</param>
+        /// <param name="lineBuilder">The converted string line to construct from the bytes</param>
+        protected void SaveSTDOutput(byte[] buffer, int count, StringBuilder lineBuilder)
         {
-            string? output = data.Data;
-            if (output == null)
+            if (count <= 0)
                 return;
 
             lock (_outputLock)
             {
-                byte[] bytes = Encoding.UTF8.GetBytes(output + Environment.NewLine);
-                _stdOutput.Write(bytes, 0, bytes.Length);
+                _stdOutput.Write(buffer, 0, count);
             }
+
+            if (STDOutputReceived?.GetInvocationList().Length > 0)
+                ParseAndInvokeLine(buffer, count, lineBuilder, line => STDOutputReceived?.Invoke(this, CreateEventArgs(line)));
         }
 
         /// <summary>
-        /// Saves the standard error from the process internally.
+        /// Saves the Standard Error from the process internally and invokes the receiver
         /// </summary>
-        /// <param name="sender">Object sending the event</param>
-        /// <param name="data">Data received by the event</param>
-        protected void SaveSTDError(object sender, DataReceivedEventArgs data)
+        /// <param name="buffer">Buffer of bytes to write</param>
+        /// <param name="count">Number of bytes to write</param>
+        /// <param name="lineBuilder">The converted string line to construct from the bytes</param>
+        protected void SaveSTDError(byte[] buffer, int count, StringBuilder lineBuilder)
         {
-            string? output = data.Data;
-            if (output == null)
+            if (count <= 0)
                 return;
 
             lock (_errorLock)
             {
-                byte[] bytes = Encoding.UTF8.GetBytes(output + Environment.NewLine);
-                _stdError.Write(bytes, 0, bytes.Length);
+                _stdError.Write(buffer, 0, count);
+            }
+
+            if (STDErrorReceived?.GetInvocationList().Length > 0)
+                ParseAndInvokeLine(buffer, count, lineBuilder, line => STDErrorReceived?.Invoke(this, CreateEventArgs(line)));
+        }
+
+        private void ParseAndInvokeLine(byte[] buffer, int count, StringBuilder lineBuilder, Action<string> onLineParsed)
+        {
+            Logger.Info("Parsing and Invoking line");
+
+            string textChunk = Encoding.UTF8.GetString(buffer, 0, count);
+
+            for (int i = 0; i < textChunk.Length; i++)
+            {
+                char c = textChunk[i];
+
+                if (c == '\n')
+                {
+                    onLineParsed(lineBuilder.ToString());
+                    lineBuilder.Clear();
+                }
+                else if (c == '\r')
+                {
+                    lineBuilder.Append(c);
+                }
+            }
+        }
+
+        private DataReceivedEventArgs CreateEventArgs(string? lineData)
+        {
+            Logger.Info("Creating Event Args for Invoke");
+
+            object[] data = new object[0];
+
+            if (!string.IsNullOrEmpty(lineData))
+            {
+                Logger.Info("Stuffed with something")
+                data = new object[] { lineData };
+            }
+               
+
+            Logger.Info($"Data is : {data[0].ToString()}");
+
+            return (DataReceivedEventArgs)Activator.CreateInstance(
+                typeof(DataReceivedEventArgs),
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null,
+                data,
+                null
+            )!;
+        }
+
+        private delegate void StreamChunkProcessor(byte[] buffer, int bytesRead, StringBuilder lineBuilder);
+
+        private Task CreateWriterTask(Stream stream, StreamChunkProcessor processor, DataReceivedEventHandler? handler)
+        {
+            return Task.Run(async () =>
+            {
+                StringBuilder lineBuilder = new StringBuilder();
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+
+                while ((bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                {
+                    processor.Invoke(buffer, bytesRead, lineBuilder);
+                }
+
+                if (lineBuilder.Length > 0 && handler?.GetInvocationList().Length > 0)
+                    handler?.Invoke(this, CreateEventArgs(lineBuilder.ToString()));
+            });
+        }
+
+        /// <summary>
+        /// Safely awaits background streaming tasks with a hard timeout to prevent deadlocks during abnormal process aborts.
+        /// </summary>
+        private async Task SafeAwaitStreamsAsync(List<Task> streamTasks)
+        {
+            try
+            {
+                Task streamWaitTask = Task.WhenAll(streamTasks);
+                Task timeoutFallback = Task.Delay(2000);
+
+                Task completedTask = await Task.WhenAny(streamWaitTask, timeoutFallback).ConfigureAwait(false);
+                if (completedTask == timeoutFallback)
+                {
+                    Logger.Warn("Stream synchronization tasks timed out during fallback termination.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error occurred wrapping up process stream threads.");
             }
         }
 
@@ -275,16 +404,65 @@ namespace NanoDNA.ProcessRunner
                     return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, "Process is null");
                 }
 
-                process.OutputDataReceived += STDOutputReceived;
-                process.ErrorDataReceived += STDErrorReceived;
-                process.OutputDataReceived += (sender, data) => SaveSTDOutput(sender, data);
-                process.ErrorDataReceived += (sender, data) => SaveSTDError(sender, data);
+                //process.OutputDataReceived += STDOutputReceived;
+                //process.ErrorDataReceived += STDErrorReceived;
+                //process.OutputDataReceived += (sender, data) => SaveSTDOutput(sender, data);
+                //process.ErrorDataReceived += (sender, data) => SaveSTDError(sender, data);
+
+                //if (STDOutputRedirect)
+                //    process.BeginOutputReadLine();
+
+                //if (STDErrorRedirect)
+                //    process.BeginErrorReadLine();
+
+                List<Task> streamTasks = new List<Task>();
+                //StringBuilder outLineBuilder = new StringBuilder();
+                //StringBuilder errLineBuilder = new StringBuilder();
 
                 if (STDOutputRedirect)
-                    process.BeginOutputReadLine();
+                    streamTasks.Add(CreateWriterTask(process.StandardOutput.BaseStream, SaveSTDOutput, STDOutputReceived));
 
                 if (STDErrorRedirect)
-                    process.BeginErrorReadLine();
+                    streamTasks.Add(CreateWriterTask(process.StandardError.BaseStream, SaveSTDError, STDErrorReceived));
+
+
+                //if (STDOutputRedirect)
+                //{
+                //    streamTasks.Add(Task.Run(async () =>
+                //    {
+                //        byte[] buffer = new byte[4096];
+                //        int bytesRead;
+
+                //        Stream baseStream = process.StandardOutput.BaseStream;
+
+                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                //        {
+                //            SaveSTDOutput(buffer, bytesRead, outLineBuilder);
+                //        }
+
+                //        if (outLineBuilder.Length > 0 && STDOutputReceived?.GetInvocationList().Length > 0)
+                //            STDOutputReceived?.Invoke(this, CreateEventArgs(outLineBuilder.ToString()));
+                //    }));
+                //}
+
+                //if (STDErrorRedirect)
+                //{
+                //    streamTasks.Add(Task.Run(async () =>
+                //    {
+                //        byte[] buffer = new byte[4096];
+                //        int bytesRead;
+
+                //        Stream baseStream = process.StandardError.BaseStream;
+
+                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                //        {
+                //            SaveSTDError(buffer, bytesRead, errLineBuilder);
+                //        }
+
+                //        if (outLineBuilder.Length > 0 && STDErrorReceived?.GetInvocationList().Length > 0)
+                //            STDErrorReceived?.Invoke(this, CreateEventArgs(errLineBuilder.ToString()));
+                //    }));
+                //}
 
                 bool exited = true;
 
@@ -300,11 +478,24 @@ namespace NanoDNA.ProcessRunner
                     process.Kill(entireProcessTree: true);
                     process.WaitForExit();
 
+                    Task.WaitAll(SafeAwaitStreamsAsync(streamTasks));
+                    //try
+                    //{
+                    //    Task.WaitAll(streamTasks.ToArray(), TimeSpan.FromSeconds(2));
+                    //}
+                    //catch (Exception ex)
+                    //{
+                    //    Logger.Warn($"Stream tasks failed to unwind cleanly on timeout: {ex.Message}");
+                    //}
+
                     return new Result<int>(ResultStatus.Cancelled, FAILED_TO_RUN_EXIT_CODE, $"Command timed out: {command}");
                 }
 
+                Task.WaitAll(SafeAwaitStreamsAsync(streamTasks));
+
                 if (process.ExitCode == 0)
                 {
+                    Task.WaitAll(streamTasks.ToArray());
                     Logger.Info($"Successfully Ran Command : {command}");
                     return new Result<int>(ResultStatus.Success, process.ExitCode, $"Command executed successfully: {command}");
                 }
@@ -333,20 +524,74 @@ namespace NanoDNA.ProcessRunner
                     return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, "Process is null");
                 }
 
-                process.OutputDataReceived += STDOutputReceived;
-                process.ErrorDataReceived += STDErrorReceived;
-                process.OutputDataReceived += (sender, data) => SaveSTDOutput(sender, data);
-                process.ErrorDataReceived += (sender, data) => SaveSTDError(sender, data);
+                //process.OutputDataReceived += STDOutputReceived;
+                //process.ErrorDataReceived += STDErrorReceived;
+                //process.OutputDataReceived += (sender, data) => SaveSTDOutput(sender, data);
+                //process.ErrorDataReceived += (sender, data) => SaveSTDError(sender, data);
+
+                //if (STDOutputRedirect)
+                //    process.BeginOutputReadLine();
+
+                //if (STDErrorRedirect)
+                //    process.BeginErrorReadLine();
+
+                List<Task> streamTasks = new List<Task>();
+                //StringBuilder outLineBuilder = new StringBuilder();
+                //StringBuilder errLineBuilder = new StringBuilder();
 
                 if (STDOutputRedirect)
-                    process.BeginOutputReadLine();
+                    streamTasks.Add(CreateWriterTask(process.StandardOutput.BaseStream, SaveSTDOutput, STDOutputReceived));
 
                 if (STDErrorRedirect)
-                    process.BeginErrorReadLine();
+                    streamTasks.Add(CreateWriterTask(process.StandardError.BaseStream, SaveSTDError, STDErrorReceived));
+
+                //if (STDOutputRedirect)
+                //{
+                //    Logger.Info("Adding stream task");
+                //    streamTasks.Add(Task.Run(async () =>
+                //    {
+                //        byte[] buffer = new byte[4096];
+                //        int bytesRead;
+
+                //        Stream baseStream = process.StandardOutput.BaseStream;
+
+                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                //        {
+                //            SaveSTDOutput(buffer, bytesRead, outLineBuilder);
+                //        }
+
+                //        if (outLineBuilder.Length > 0)
+                //        {
+                //            Logger.Info("Invoking");
+                //            STDOutputReceived?.Invoke(this, CreateEventArgs(outLineBuilder.ToString()));
+                //        }
+
+                //    }));
+                //}
+
+                //if (STDErrorRedirect)
+                //{
+                //    streamTasks.Add(Task.Run(async () =>
+                //    {
+                //        byte[] buffer = new byte[4096];
+                //        int bytesRead;
+
+                //        Stream baseStream = process.StandardError.BaseStream;
+
+                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                //        {
+                //            SaveSTDError(buffer, bytesRead, errLineBuilder);
+                //        }
+
+                //        if (errLineBuilder.Length > 0)
+                //            STDErrorReceived?.Invoke(this, CreateEventArgs(errLineBuilder.ToString()));
+                //    }));
+                //}
 
                 try
                 {
                     await process.WaitForExitAsync(cancellationToken);
+                    await SafeAwaitStreamsAsync(streamTasks);
                 }
                 catch
                 {
@@ -363,25 +608,29 @@ namespace NanoDNA.ProcessRunner
                     bool graceCondition = completedKillTask == gracePeriodTask && !process.HasExited;
                     bool killErrorCondition = completedKillTask == killTask && killTask.Exception != null;
 
-                    if (graceCondition)
+                    if (graceCondition || killErrorCondition)
                     {
-                        Logger.Warn($"Process did not exit within the grace period. Force killing process tree: {command}");
+                        string condition = graceCondition ? "did not exit within the grace period" : "cancellation resulted in an error";
+
+                        Logger.Warn($"Process {condition}. Force killing process tree: {command}");
 
                         process.Kill(entireProcessTree: true);
                         await process.WaitForExitAsync(CancellationToken.None);
+                        await SafeAwaitStreamsAsync(streamTasks);
 
                         return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, $"Command was canceled and was killed forcefully: {command}");
                     }
 
-                    if (killErrorCondition)
-                    {
-                        Logger.Warn($"Process cancellation resulted in an error. Force killing process tree: {command}");
+                    //if (killErrorCondition)
+                    //{
+                    //    Logger.Warn($"Process cancellation resulted in an error. Force killing process tree: {command}");
 
-                        process.Kill(entireProcessTree: true);
-                        await process.WaitForExitAsync(CancellationToken.None);
+                    //    process.Kill(entireProcessTree: true);
+                    //    await process.WaitForExitAsync(CancellationToken.None);
+                    //    await SafeAwaitStreamsAsync(streamTasks);
 
-                        return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, $"Command was canceled and was killed forcefully: {command}");
-                    }
+                    //    return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, $"Command was canceled and was killed forcefully: {command}");
+                    //}
 
                     return new Result<int>(ResultStatus.Cancelled, FAILED_TO_RUN_EXIT_CODE, $"Command was canceled and exited gracefully: {command}");
                 }

--- a/ProcessRunner/BaseProcessRunner.cs
+++ b/ProcessRunner/BaseProcessRunner.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using NanoDNA.AutomationResults;
 using System.Collections.Generic;
-using NLog.LayoutRenderers.Wrappers;
 
 namespace NanoDNA.ProcessRunner
 {
@@ -224,42 +223,6 @@ namespace NanoDNA.ProcessRunner
             Logger.Debug($"Working Directory : {path}");
         }
 
-        ///// <summary>
-        ///// Saves the standard output from the process internally.
-        ///// </summary>
-        ///// <param name="sender">Object sending the event</param>
-        ///// <param name="data">Data received by the event</param>
-        //protected void SaveSTDOutput(object sender, DataReceivedEventArgs data)
-        //{
-        //    string? output = data.Data;
-        //    if (output == null)
-        //        return;
-
-        //    lock (_outputLock)
-        //    {
-        //        byte[] bytes = Encoding.UTF8.GetBytes(output + Environment.NewLine);
-        //        _stdOutput.Write(bytes, 0, bytes.Length);
-        //    }
-        //}
-
-        ///// <summary>
-        ///// Saves the standard error from the process internally.
-        ///// </summary>
-        ///// <param name="sender">Object sending the event</param>
-        ///// <param name="data">Data received by the event</param>
-        //protected void SaveSTDError(object sender, DataReceivedEventArgs data)
-        //{
-        //    string? output = data.Data;
-        //    if (output == null)
-        //        return;
-
-        //    lock (_errorLock)
-        //    {
-        //        byte[] bytes = Encoding.UTF8.GetBytes(output + Environment.NewLine);
-        //        _stdError.Write(bytes, 0, bytes.Length);
-        //    }
-        //}
-
         /// <summary>
         /// Saves the Standard Output from the process internally and invokes the receiver
         /// </summary>
@@ -398,65 +361,12 @@ namespace NanoDNA.ProcessRunner
                     return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, "Process is null");
                 }
 
-                //process.OutputDataReceived += STDOutputReceived;
-                //process.ErrorDataReceived += STDErrorReceived;
-                //process.OutputDataReceived += (sender, data) => SaveSTDOutput(sender, data);
-                //process.ErrorDataReceived += (sender, data) => SaveSTDError(sender, data);
-
-                //if (STDOutputRedirect)
-                //    process.BeginOutputReadLine();
-
-                //if (STDErrorRedirect)
-                //    process.BeginErrorReadLine();
-
                 List<Task> streamTasks = new List<Task>();
-                //StringBuilder outLineBuilder = new StringBuilder();
-                //StringBuilder errLineBuilder = new StringBuilder();
-
                 if (STDOutputRedirect)
                     streamTasks.Add(CreateWriterTask(process.StandardOutput.BaseStream, SaveSTDOutput, STDOutputReceived));
 
                 if (STDErrorRedirect)
                     streamTasks.Add(CreateWriterTask(process.StandardError.BaseStream, SaveSTDError, STDErrorReceived));
-
-
-                //if (STDOutputRedirect)
-                //{
-                //    streamTasks.Add(Task.Run(async () =>
-                //    {
-                //        byte[] buffer = new byte[4096];
-                //        int bytesRead;
-
-                //        Stream baseStream = process.StandardOutput.BaseStream;
-
-                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
-                //        {
-                //            SaveSTDOutput(buffer, bytesRead, outLineBuilder);
-                //        }
-
-                //        if (outLineBuilder.Length > 0 && STDOutputReceived?.GetInvocationList().Length > 0)
-                //            STDOutputReceived?.Invoke(this, CreateEventArgs(outLineBuilder.ToString()));
-                //    }));
-                //}
-
-                //if (STDErrorRedirect)
-                //{
-                //    streamTasks.Add(Task.Run(async () =>
-                //    {
-                //        byte[] buffer = new byte[4096];
-                //        int bytesRead;
-
-                //        Stream baseStream = process.StandardError.BaseStream;
-
-                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
-                //        {
-                //            SaveSTDError(buffer, bytesRead, errLineBuilder);
-                //        }
-
-                //        if (outLineBuilder.Length > 0 && STDErrorReceived?.GetInvocationList().Length > 0)
-                //            STDErrorReceived?.Invoke(this, CreateEventArgs(errLineBuilder.ToString()));
-                //    }));
-                //}
 
                 bool exited = true;
 
@@ -471,16 +381,7 @@ namespace NanoDNA.ProcessRunner
 
                     process.Kill(entireProcessTree: true);
                     process.WaitForExit();
-
                     Task.WaitAll(SafeAwaitStreamsAsync(streamTasks));
-                    //try
-                    //{
-                    //    Task.WaitAll(streamTasks.ToArray(), TimeSpan.FromSeconds(2));
-                    //}
-                    //catch (Exception ex)
-                    //{
-                    //    Logger.Warn($"Stream tasks failed to unwind cleanly on timeout: {ex.Message}");
-                    //}
 
                     return new Result<int>(ResultStatus.Cancelled, FAILED_TO_RUN_EXIT_CODE, $"Command timed out: {command}");
                 }
@@ -518,69 +419,13 @@ namespace NanoDNA.ProcessRunner
                     return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, "Process is null");
                 }
 
-                //process.OutputDataReceived += STDOutputReceived;
-                //process.ErrorDataReceived += STDErrorReceived;
-                //process.OutputDataReceived += (sender, data) => SaveSTDOutput(sender, data);
-                //process.ErrorDataReceived += (sender, data) => SaveSTDError(sender, data);
-
-                //if (STDOutputRedirect)
-                //    process.BeginOutputReadLine();
-
-                //if (STDErrorRedirect)
-                //    process.BeginErrorReadLine();
-
                 List<Task> streamTasks = new List<Task>();
-                //StringBuilder outLineBuilder = new StringBuilder();
-                //StringBuilder errLineBuilder = new StringBuilder();
 
                 if (STDOutputRedirect)
                     streamTasks.Add(CreateWriterTask(process.StandardOutput.BaseStream, SaveSTDOutput, STDOutputReceived));
 
                 if (STDErrorRedirect)
                     streamTasks.Add(CreateWriterTask(process.StandardError.BaseStream, SaveSTDError, STDErrorReceived));
-
-                //if (STDOutputRedirect)
-                //{
-                //    Logger.Info("Adding stream task");
-                //    streamTasks.Add(Task.Run(async () =>
-                //    {
-                //        byte[] buffer = new byte[4096];
-                //        int bytesRead;
-
-                //        Stream baseStream = process.StandardOutput.BaseStream;
-
-                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
-                //        {
-                //            SaveSTDOutput(buffer, bytesRead, outLineBuilder);
-                //        }
-
-                //        if (outLineBuilder.Length > 0)
-                //        {
-                //            Logger.Info("Invoking");
-                //            STDOutputReceived?.Invoke(this, CreateEventArgs(outLineBuilder.ToString()));
-                //        }
-
-                //    }));
-                //}
-
-                //if (STDErrorRedirect)
-                //{
-                //    streamTasks.Add(Task.Run(async () =>
-                //    {
-                //        byte[] buffer = new byte[4096];
-                //        int bytesRead;
-
-                //        Stream baseStream = process.StandardError.BaseStream;
-
-                //        while ((bytesRead = await baseStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
-                //        {
-                //            SaveSTDError(buffer, bytesRead, errLineBuilder);
-                //        }
-
-                //        if (errLineBuilder.Length > 0)
-                //            STDErrorReceived?.Invoke(this, CreateEventArgs(errLineBuilder.ToString()));
-                //    }));
-                //}
 
                 try
                 {
@@ -614,17 +459,6 @@ namespace NanoDNA.ProcessRunner
 
                         return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, $"Command was canceled and was killed forcefully: {command}");
                     }
-
-                    //if (killErrorCondition)
-                    //{
-                    //    Logger.Warn($"Process cancellation resulted in an error. Force killing process tree: {command}");
-
-                    //    process.Kill(entireProcessTree: true);
-                    //    await process.WaitForExitAsync(CancellationToken.None);
-                    //    await SafeAwaitStreamsAsync(streamTasks);
-
-                    //    return new Result<int>(ResultStatus.Error, FAILED_TO_RUN_EXIT_CODE, $"Command was canceled and was killed forcefully: {command}");
-                    //}
 
                     return new Result<int>(ResultStatus.Cancelled, FAILED_TO_RUN_EXIT_CODE, $"Command was canceled and exited gracefully: {command}");
                 }


### PR DESCRIPTION
* Refactored process stream processing from event-driven BeginOutputReadLine / BeginErrorReadLine system methods to direct, background asynchronous Stream.ReadAsync task loops via CreateWriterTask.
* Fixed a text-encoding conversion bug by ensuring standard outputs and standard errors preserve raw multi-byte binary sequences and binary layout integrity directly inside internal MemoryStream buffers (_stdOutput and _stdError).
* Added string validation logic in ParseAndInvokeLine to actively track trailing Carriage Returns (\r) and emit line variations up to custom subscription event handlers (STDOutputReceived and STDErrorReceived) seamlessly.
* Updated Task asynchronous execution wrappers in both synchronous Run and asynchronous RunAsync method contexts to securely wait for asynchronous background data operations via a newly introduced SafeAwaitStreamsAsync handler sequence.
* Optimized process tracing over critical run routes by switching excessively active notification traces to granular Logger.Trace logging flags.
* Added validation coverage across missing stream and event-handling edge cases:
    * RunWithRawBytesAndBase64OutputCapturesCorrectBytes ensures base64 and zero/non-alphanumeric bytes map correctly to STDOutputBytes.
    * RunAsyncWithRawBytesAndBase64OutputCapturesCorrectBytes checks async multi-byte standard output and standard error stream flows.
    * Run_Subscription_ReceivesLineByLineOutputCorrectly tests consecutive formatting endpoints (\n, \r\n) through internal layout reflection paths.
    * RunAsyncSubscriptionReceivesLineByLineOutputCorrectly covers async thread subscription and event line multi-threading.
    * RunSubscriptionHandlesTrailingTextWithoutNewline ensures buffers catch hanging texts that lack final breaks.
    * RunSubscriptionHandlesWhitespaceLines verifies that white-spaced elements are cleanly forwarded instead of discarded.
    * SaveSTDOutputWithZeroCountDoesNotInvokeEvent validates that empty block limits evaluate securely without invoking sub-tasks.